### PR TITLE
Author Char limit fix

### DIFF
--- a/TabloidCLI/UserInterfaceManagers/AuthorManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/AuthorManager.cs
@@ -182,11 +182,7 @@ namespace TabloidCLI.UserInterfaceManagers
             Console.WriteLine();
             Console.Write("New first name (blank to leave unchanged): ");
             string firstName = Console.ReadLine();
-            if (!string.IsNullOrWhiteSpace(firstName))
-            {
-                authorToEdit.FirstName = firstName;
-            }
-            else if (firstName.Length > 55)
+            if (firstName.Length > 55)
             {
                 Console.WriteLine();
                 Console.WriteLine("First name must be 55 characters or less.");
@@ -194,20 +190,24 @@ namespace TabloidCLI.UserInterfaceManagers
 
                 goto firstNameEdit;
             }
+            else if (!string.IsNullOrWhiteSpace(firstName))
+            {
+                authorToEdit.FirstName = firstName;
+            } 
             lastNameEdit:
             Console.Write("New last name (blank to leave unchanged): ");
             string lastName = Console.ReadLine();
-            if (!string.IsNullOrWhiteSpace(lastName))
-            {
-                authorToEdit.LastName = lastName;
-            }
-            else if (firstName.Length > 55)
+
+            if (lastName.Length > 55)
             {
                 Console.WriteLine();
                 Console.WriteLine("Last name must be 55 characters or less.");
                 Console.WriteLine();
 
                 goto lastNameEdit;
+            } else if (!string.IsNullOrWhiteSpace(lastName))
+            {
+                authorToEdit.LastName = lastName;
             }
             Console.Write("New bio (blank to leave unchanged): ");
             string bio = Console.ReadLine();

--- a/TabloidCLI/UserInterfaceManagers/AuthorManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/AuthorManager.cs
@@ -78,6 +78,9 @@ namespace TabloidCLI.UserInterfaceManagers
         
         private Author Choose(string prompt = null)
         {
+
+            // label in case exception is thrown
+            ChooseAuthor:
             if (prompt == null)
             {
                 prompt = "Please choose an Author:";
@@ -102,8 +105,10 @@ namespace TabloidCLI.UserInterfaceManagers
             }
             catch (Exception)
             {
+                Console.WriteLine();
                 Console.WriteLine("Invalid Selection");
-                return null;
+                Console.WriteLine();
+                goto ChooseAuthor;
             }
         }
 
@@ -118,10 +123,17 @@ namespace TabloidCLI.UserInterfaceManagers
             FirstName: 
             Console.Write("First Name: ");
             author.FirstName = Console.ReadLine();
-            if (author.FirstName == "")
+            if (string.IsNullOrEmpty(author.FirstName))
             {
                 Console.WriteLine();
                 Console.WriteLine("Please Enter a name.");
+                Console.WriteLine();
+
+                goto FirstName;
+            } else if (author.FirstName.Length > 55)
+            {
+                Console.WriteLine();
+                Console.WriteLine("First name must be 55 characters or less.");
                 Console.WriteLine();
 
                 goto FirstName;
@@ -131,11 +143,18 @@ namespace TabloidCLI.UserInterfaceManagers
             Console.Write("Last Name: ");
             author.LastName = Console.ReadLine();
 
-            if (author.LastName == "")
+            if (string.IsNullOrEmpty(author.LastName))
             {
                 Console.WriteLine();
                 Console.WriteLine("Please Enter a name.");
                 Console.WriteLine();
+                goto LastName;
+            } else if (author.LastName.Length > 55)
+            {
+                Console.WriteLine();
+                Console.WriteLine("Last name must be 55 characters or less.");
+                Console.WriteLine();
+
                 goto LastName;
             }
             Bio:
@@ -161,7 +180,7 @@ namespace TabloidCLI.UserInterfaceManagers
             {
                 return;
             }
-
+            firstNameEdit:
             Console.WriteLine();
             Console.Write("New first name (blank to leave unchanged): ");
             string firstName = Console.ReadLine();
@@ -169,11 +188,28 @@ namespace TabloidCLI.UserInterfaceManagers
             {
                 authorToEdit.FirstName = firstName;
             }
+            else if (firstName.Length > 55)
+            {
+                Console.WriteLine();
+                Console.WriteLine("First name must be 55 characters or less.");
+                Console.WriteLine();
+
+                goto firstNameEdit;
+            }
+            lastNameEdit:
             Console.Write("New last name (blank to leave unchanged): ");
             string lastName = Console.ReadLine();
             if (!string.IsNullOrWhiteSpace(lastName))
             {
                 authorToEdit.LastName = lastName;
+            }
+            else if (firstName.Length > 55)
+            {
+                Console.WriteLine();
+                Console.WriteLine("Last name must be 55 characters or less.");
+                Console.WriteLine();
+
+                goto lastNameEdit;
             }
             Console.Write("New bio (blank to leave unchanged): ");
             string bio = Console.ReadLine();


### PR DESCRIPTION
# Description
- added quick fix to prevent crash upon posting a name larger than the database allows

Fixes # (issue)
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
# Testing Instructions
- clone repo
- navigate to home directory
- dotnet run
- navigate to author section via program menu
- in either edit or add attempt to insert an author string greater than 55 characters
# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works